### PR TITLE
Use correct puppetmaster server on install server

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ to master).
 
 To do that, just connect as root on the puppetmaster node and run apply-in-review-patches.sh.
 You may have some manual merges to do ... :/
+```
+# ./apply-in-review-patches.sh /opt/system-config/production/ reset
+# ./apply-in-review-patches.sh /opt/system-config/production/ apply
+```
 
 ### Tips
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ $ ps axf # Will show some LXC containers up
 $ ./prepare-hieradata.sh # A /tmp/defaults.yaml will be created and consume by Ansible below
 ```
 
+#### Disable ssh control socket
+```
+$ sudo sed -i 's/^#*ssh_args =.*/ssh_args = -o ControlMaster=no/' /etc/ansible/ansible.cfg
+```
 
 #### Configure the puppetmaster node:
 Running puppetmaster.yaml playbook will setup the puppetmaster node by installing puppet

--- a/prepare-node.sh
+++ b/prepare-node.sh
@@ -11,7 +11,7 @@ chmod og+w /dev/null
 
 # Normal preparation
 echo "nameserver 8.8.8.8" | tee /etc/resolv.conf
-aptitude update
+aptitude update || exit -1
 #DEBIAN_FRONTEND=noninteractive aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" safe-upgrade
 aptitude install -y git vim puppet
 

--- a/prepare-puppetmaster.sh
+++ b/prepare-puppetmaster.sh
@@ -10,7 +10,7 @@ chmod og+w /dev/null
 
 # Normal preparation
 echo "nameserver 8.8.8.8" | tee /etc/resolv.conf
-aptitude update
+aptitude update || exit -1
 #DEBIAN_FRONTEND=noninteractive aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" safe-upgrade
 aptitude install -y git vim
 
@@ -31,12 +31,8 @@ class { 'openstack_project::puppetmaster':
     # We overwrite the key after the run of that manifest
     root_rsa_key => 'XXX',
     puppetdb => false,
+    puppetmaster_server => 'puppetmaster.test.localdomain',
 }
-EOF
-
-cat << EOF > /etc/ansible/ansible.cfg
-[ssh_connection]
-ssh_args = -o ControlMaster=no
 EOF
 
 puppet apply --modulepath='/opt/system-config/production/modules:/etc/puppet/modules' /root/install-puppetmaster.pp


### PR DESCRIPTION
This change make sure the puppetmaster is well configured on the install server.

It also updates the documentation to avoir failing playbooks because of shared connection being lost.
